### PR TITLE
License specification update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,12 @@ authors = [
     {name = "Alphacruncher", email = "support@nuvolos.cloud"}
 ]
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
I had to create an update due to the PyPI upload complaining of incorrect license specification, even though `twine check ./dist/*" ran successfully locally.